### PR TITLE
Remove outdated October meetup details

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,7 @@
 <center>
 <img src="PDX2600.png" width="30%"><br>
 First Fridays, 6:30pm<br>
-October: <s><b>Honey Latte Cafe</b><br>1033 SE Main St</s>
-<br><br>
-  <b>Just kidding, Lucky Lab SE</b><br>915 SE Hawthorne Blvd.
+November: <b>Fast Times</b><br>624 E Burnside
 <br><br>
   
   <a href="https://signal.group/#CjQKIBvLBpxbASCacy0-_oq_9johbE5jwDDL7ShQ42PG0y6oEhBFyrHgMbZCqmdtzOF0xdIp">Signal Chat</a>


### PR DESCRIPTION
## Summary
- remove outdated October meetup listing so only November details are shown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69069f3054f08323891ff19e5781d81b