### PR TITLE
Update Fast Times meetup location

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,16 +5,15 @@
 <center>
 <img src="PDX2600.png" width="30%"><br>
 First Fridays, 6:30pm<br>
-November: <b>Fast Times</b><br>624 E Burnside
+<br>
+<b>Fast Times</b><br>624 E Burnside
 <br><br>
-  
+
   <a href="https://signal.group/#CjQKIBvLBpxbASCacy0-_oq_9johbE5jwDDL7ShQ42PG0y6oEhBFyrHgMbZCqmdtzOF0xdIp">Signal Chat</a>
 <br><br>
 Follow us:<br>
 <a rel="me" href="https://mastodon.online/@pdx2600">@pdx2600@mastodon.online</a><br>
 @PDX2600 on Twitter<br><br>
-
-note: Our Sizzle Pie got shut down in February 2025 for daring to unionize,<br>so we're in the process of looking for new options.
 
 </center>
 


### PR DESCRIPTION
## Summary
- mark Fast Times as the permanent meetup location with clearer spacing above the address
- remove outdated note about the temporary search for a venue

## Testing
- not run (static site change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69333035ab3083239f65ade7a23e41e1)